### PR TITLE
Improve sorting by :definition with more than 10 attributes in the list

### DIFF
--- a/lib/oj_serializers/serializer.rb
+++ b/lib/oj_serializers/serializer.rb
@@ -713,7 +713,13 @@ protected
       if sort_by == :name
         sort_by = ->(name, options, _) { options[:identifier] ? "__#{name}" : name }
       elsif !sort_by || sort_by == :definition
-        sort_by = ->(name, options, index) { options[:identifier] ? "__#{name}" : "zzz#{index}" }
+        sort_by = ->(name, options, index) {
+          if options[:identifier]
+            0 - (_attributes.count - index)
+          else
+            index
+          end
+        }
       end
 
       attributes.sort_by.with_index { |(name, options), index| sort_by.call(name, options, index) }.to_h

--- a/spec/oj_serializers/sort_attributes_spec.rb
+++ b/spec/oj_serializers/sort_attributes_spec.rb
@@ -3,12 +3,20 @@
 require 'spec_helper'
 require 'support/models/album'
 require 'support/serializers/album_serializer'
+require 'support/serializers/large_album_serializer'
 
 class SortedAlbumSerializer < AlbumSerializer
   sort_attributes_by :name
 end
 
 class UnsortedAlbumSerializer < AlbumSerializer
+  sort_attributes_by :definition
+  transform_keys :none
+
+  identifier :release_date
+end
+
+class UnsortedLargeAlbumSerializer < LargeAlbumSerializer
   sort_attributes_by :definition
   transform_keys :none
 
@@ -37,6 +45,12 @@ RSpec.describe 'sort_attributes_by' do
   it 'should sort attributes by definition order' do
     expect_parsed_json(UnsortedAlbumSerializer.one(album)).to have_attributes(
       keys: %i[id release_date name genres release songs],
+    )
+  end
+
+  it 'should sort large attributes list by definition order' do
+    expect_parsed_json(UnsortedLargeAlbumSerializer.one(album)).to have_attributes(
+      keys: %i[id release_date name genres release songs year day month band label producer]
     )
   end
 end

--- a/spec/support/serializers/large_album_serializer.rb
+++ b/spec/support/serializers/large_album_serializer.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require_relative 'album_serializer'
+
+class LargeAlbumSerializer < AlbumSerializer
+  attribute :year do
+    "2021"
+  end
+
+  attribute :day do
+    23
+  end
+
+  attribute :month do
+    "March"
+  end
+
+  attribute :band do
+    "Unknown"
+  end
+
+  attribute :label do
+    "Label"
+  end
+
+  attribute :producer do
+    "Producer"
+  end
+end


### PR DESCRIPTION
Fixes a bug described here: https://github.com/ElMassimo/oj_serializers/issues/24